### PR TITLE
Add simple script to verify presence of exercise directories

### DIFF
--- a/bin/verify_exercises_exist
+++ b/bin/verify_exercises_exist
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+ROOT=$(pwd)
+
+for language in $(ls exercises)
+do
+    cd exercises/$language
+    while read exercise;
+    do
+        # ignore comments and empty lines
+        initial="$(echo $exercise | head -c 1)"
+        if [ "$initial" == "#" ] || [ "$initial" == "" ]; then
+            continue;
+        fi
+
+        # fail if exercise directory does not exist
+        if [ ! -d "$exercise" ]; then
+            echo "$exercise not found for language $language" 1>&2
+            echo "   -one possibility is that you haven't run:" 1>&2
+            echo "      $ git submodule init && git submodule update" 1>&2
+            exit 1
+        fi
+    done < EXERCISES.txt
+    cd $ROOT
+done


### PR DESCRIPTION
This is a very simple first step towards a solution to issue #6. Right now this works from x-api once you've init and update your submodules. It simply checks that each exercise listed has a corresponding directory present. If it doesn't it outputs some text to stderr and exits 1. I'm sure there is a lot more we can do here, but again, this might be a start. Let me know what you think.
