### PR TITLE
Fix README to point to existing endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Puma 2.7.1 starting...
 ```
 
 At this point you can navigate to an existing endpoint in your browser, e.g.
-[localhost:9292/problems/ruby/bob](http://localhost:9292/problems/ruby/bob)
+[localhost:9292/tracks/ruby/bob](http://localhost:9292/tracks/ruby/bob)
 
 **If you're not seeing any problems it is probably because you haven't
 updated or inititialized the submodules. Be sure to work through the


### PR DESCRIPTION
The example endpoint in the "Running Locally" section is no longer valid. This commit changes the example to an existing endpoint.