### PR TITLE
Call Exercism API to mark new problems as fetched

### DIFF
--- a/lib/xapi/exercism_io.rb
+++ b/lib/xapi/exercism_io.rb
@@ -19,11 +19,15 @@ module Xapi
     end
 
     def self.exercises_for(key)
-      request '/api/v1/exercises', key
+      get '/api/v1/exercises', key
     end
 
     def self.code_for(key)
-      request('/api/v1/iterations/latest', key)["assignments"]
+      get('/api/v1/iterations/latest', key)["assignments"]
+    end
+
+    def self.fetch_for(key, language, slug)
+      post("/api/v1/iterations/#{language}/#{slug}/fetch", key)
     end
 
     def self.conn
@@ -32,13 +36,21 @@ module Xapi
       end
     end
 
-    def self.request(path, key)
-      response = conn.get do |req|
+    def self.get(path, key)
+      request(:get, path, key)
+    end
+
+    def self.post(path, key)
+      request(:post, path, key)
+    end
+
+    def self.request(verb, path, key)
+      response = conn.send(verb) do |req|
         req.url File.join(path)
         req.headers['User-Agent'] = "github.com/exercism/xapi"
         req.params['key'] = key
       end
-      intercept JSON.parse(response.body)
+      intercept JSON.parse(response.body) unless response.body.empty?
     end
 
     def self.intercept(data)

--- a/test/app/routes/exercises_test.rb
+++ b/test/app/routes/exercises_test.rb
@@ -31,7 +31,7 @@ class AppRoutesExercisesTest < Minitest::Test
   end
 
   def test_get_problems
-    VCR.use_cassette('exercism_api_current_exercises') do
+    VCR.use_cassette('exercism_api_current_exercises', record: :new_episodes) do
       get '/exercises', key: 'abc123'
 
       options = { format: :json, name: 'get_current_problems' }
@@ -48,7 +48,7 @@ class AppRoutesExercisesTest < Minitest::Test
   end
 
   def test_v2_get_problems
-    VCR.use_cassette('exercism_api_current_exercises_v2') do
+    VCR.use_cassette('exercism_api_current_exercises_v2', record: :new_episodes) do
       get '/v2/exercises', key: 'abc123'
 
       options = { format: :json, name: 'get_current_problems_v2' }

--- a/test/fixtures/approvals/get_current_problems.approved.json
+++ b/test/fixtures/approvals/get_current_problems.approved.json
@@ -24,6 +24,28 @@
       "fresh": false
     },
     {
+      "track_id": "fake",
+      "id": "three",
+      "track": "fake",
+      "slug": "three",
+      "files": {
+        "three_test.tst": "assert 'one'\n",
+        "README.md": "# Three\n\nThis is three.\n\n* three\n* three again\n\nDo stuff.\n\n## Source\n\nThe internet. [view source](http://example.com/3)\n"
+      },
+      "fresh": false
+    },
+    {
+      "track_id": "fake",
+      "id": "two",
+      "track": "fake",
+      "slug": "two",
+      "files": {
+        "two_test.tst": "assert 'one'\n",
+        "README.md": "# Two\n\nThis is two.\n\n* two\n* two again\n\nDo stuff.\n\n## Source\n\nThe internet. [view source](http://example.com)\n"
+      },
+      "fresh": false
+    },
+    {
       "track_id": "fruit",
       "id": "apple",
       "track": "fruit",
@@ -32,6 +54,28 @@
         "apple.ext": "an apple a day keeps the doctor away\n",
         "apple_test.tst": "assert 'one'\n",
         "README.md": "# Apple\n\nThis is apple.\n\n* apple\n* apple again\n\n\n## Source\n\nThe internet. [view source](http://example.com)\n"
+      },
+      "fresh": false
+    },
+    {
+      "track_id": "fruit",
+      "id": "banana",
+      "track": "fruit",
+      "slug": "banana",
+      "files": {
+        "banana_test.tst": "assert 'one'\n",
+        "README.md": "# Banana\n\nThis is banana.\n\n* banana\n* banana again\n\n\n## Source\n\nThe internet. [view source](http://example.com)\n"
+      },
+      "fresh": false
+    },
+    {
+      "track_id": "fruit",
+      "id": "cherry",
+      "track": "fruit",
+      "slug": "cherry",
+      "files": {
+        "cherry_test.tst": "assert 'one'\n",
+        "README.md": "# Cherry\n\nThis is cherry.\n\n* cherry\n* cherry again\n\n\n## Source\n\nThe internet. [view source](http://example.com)\n"
       },
       "fresh": false
     }

--- a/test/fixtures/approvals/get_current_problems_by_language.approved.json
+++ b/test/fixtures/approvals/get_current_problems_by_language.approved.json
@@ -11,6 +11,28 @@
         "README.md": "# Apple\n\nThis is apple.\n\n* apple\n* apple again\n\n\n## Source\n\nThe internet. [view source](http://example.com)\n"
       },
       "fresh": false
+    },
+    {
+      "track_id": "fruit",
+      "id": "banana",
+      "track": "fruit",
+      "slug": "banana",
+      "files": {
+        "banana_test.tst": "assert 'one'\n",
+        "README.md": "# Banana\n\nThis is banana.\n\n* banana\n* banana again\n\n\n## Source\n\nThe internet. [view source](http://example.com)\n"
+      },
+      "fresh": false
+    },
+    {
+      "track_id": "fruit",
+      "id": "cherry",
+      "track": "fruit",
+      "slug": "cherry",
+      "files": {
+        "cherry_test.tst": "assert 'one'\n",
+        "README.md": "# Cherry\n\nThis is cherry.\n\n* cherry\n* cherry again\n\n\n## Source\n\nThe internet. [view source](http://example.com)\n"
+      },
+      "fresh": false
     }
   ]
 }

--- a/test/fixtures/approvals/get_current_problems_by_language_v2.approved.json
+++ b/test/fixtures/approvals/get_current_problems_by_language_v2.approved.json
@@ -12,6 +12,30 @@
         "README.md": "# Apple\n\nThis is apple.\n\n* apple\n* apple again\n\n\n## Source\n\nThe internet. [view source](http://example.com)\n"
       },
       "fresh": false
+    },
+    {
+      "id": "fruit/banana",
+      "track_id": "fruit",
+      "language": "fruit",
+      "slug": "banana",
+      "name": "Banana",
+      "files": {
+        "banana_test.tst": "assert 'one'\n",
+        "README.md": "# Banana\n\nThis is banana.\n\n* banana\n* banana again\n\n\n## Source\n\nThe internet. [view source](http://example.com)\n"
+      },
+      "fresh": false
+    },
+    {
+      "id": "fruit/cherry",
+      "track_id": "fruit",
+      "language": "fruit",
+      "slug": "cherry",
+      "name": "Cherry",
+      "files": {
+        "cherry_test.tst": "assert 'one'\n",
+        "README.md": "# Cherry\n\nThis is cherry.\n\n* cherry\n* cherry again\n\n\n## Source\n\nThe internet. [view source](http://example.com)\n"
+      },
+      "fresh": false
     }
   ]
 }

--- a/test/fixtures/approvals/get_current_problems_v2.approved.json
+++ b/test/fixtures/approvals/get_current_problems_v2.approved.json
@@ -26,6 +26,30 @@
       "fresh": false
     },
     {
+      "id": "fake/three",
+      "track_id": "fake",
+      "language": "fake",
+      "slug": "three",
+      "name": "Three",
+      "files": {
+        "three_test.tst": "assert 'one'\n",
+        "README.md": "# Three\n\nThis is three.\n\n* three\n* three again\n\nDo stuff.\n\n## Source\n\nThe internet. [view source](http://example.com/3)\n"
+      },
+      "fresh": false
+    },
+    {
+      "id": "fake/two",
+      "track_id": "fake",
+      "language": "fake",
+      "slug": "two",
+      "name": "Two",
+      "files": {
+        "two_test.tst": "assert 'one'\n",
+        "README.md": "# Two\n\nThis is two.\n\n* two\n* two again\n\nDo stuff.\n\n## Source\n\nThe internet. [view source](http://example.com)\n"
+      },
+      "fresh": false
+    },
+    {
       "id": "fruit/apple",
       "track_id": "fruit",
       "language": "fruit",
@@ -35,6 +59,30 @@
         "apple.ext": "an apple a day keeps the doctor away\n",
         "apple_test.tst": "assert 'one'\n",
         "README.md": "# Apple\n\nThis is apple.\n\n* apple\n* apple again\n\n\n## Source\n\nThe internet. [view source](http://example.com)\n"
+      },
+      "fresh": false
+    },
+    {
+      "id": "fruit/banana",
+      "track_id": "fruit",
+      "language": "fruit",
+      "slug": "banana",
+      "name": "Banana",
+      "files": {
+        "banana_test.tst": "assert 'one'\n",
+        "README.md": "# Banana\n\nThis is banana.\n\n* banana\n* banana again\n\n\n## Source\n\nThe internet. [view source](http://example.com)\n"
+      },
+      "fresh": false
+    },
+    {
+      "id": "fruit/cherry",
+      "track_id": "fruit",
+      "language": "fruit",
+      "slug": "cherry",
+      "name": "Cherry",
+      "files": {
+        "cherry_test.tst": "assert 'one'\n",
+        "README.md": "# Cherry\n\nThis is cherry.\n\n* cherry\n* cherry again\n\n\n## Source\n\nThe internet. [view source](http://example.com)\n"
       },
       "fresh": false
     }

--- a/test/fixtures/vcr_cassettes/exercism_api_current_exercises.yml
+++ b/test/fixtures/vcr_cassettes/exercism_api_current_exercises.yml
@@ -25,10 +25,10 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Content-Length:
-      - '131'
+      - '395'
     body:
       encoding: UTF-8
-      string: '{"go":[{"slug":"leap","state":"archived"}],"haskell":[{"slug":"list-ops","state":"active"},{"slug":"word-count","state":"active"}]}'
+      string: '{"animal":[{"slug":"dog","state":"active"}],"fake":[{"slug":"one","state":"active"},{"slug":"three","state":"active"},{"slug":"two","state":"active"}],"fruit":[{"slug":"apple","state":"active"},{"slug":"banana","state":"active"},{"slug":"cherry","state":"active"}],"go":[{"slug":"leap","state":"archived"}],"haskell":[{"slug":"list-ops","state":"active"},{"slug":"word-count","state":"active"}]}'
     http_version: 
-  recorded_at: Mon, 21 Sep 2015 17:14:29 GMT
+  recorded_at: Mon, 21 Sep 2015 20:38:55 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/exercism_api_current_exercises_v2.yml
+++ b/test/fixtures/vcr_cassettes/exercism_api_current_exercises_v2.yml
@@ -25,10 +25,10 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Content-Length:
-      - '131'
+      - '395'
     body:
       encoding: UTF-8
-      string: '{"go":[{"slug":"leap","state":"archived"}],"haskell":[{"slug":"list-ops","state":"active"},{"slug":"word-count","state":"active"}]}'
+      string: '{"animal":[{"slug":"dog","state":"active"}],"fake":[{"slug":"one","state":"active"},{"slug":"three","state":"active"},{"slug":"two","state":"active"}],"fruit":[{"slug":"apple","state":"active"},{"slug":"banana","state":"active"},{"slug":"cherry","state":"active"}],"go":[{"slug":"leap","state":"archived"}],"haskell":[{"slug":"list-ops","state":"active"},{"slug":"word-count","state":"active"}]}'
     http_version: 
-  recorded_at: Mon, 21 Sep 2015 17:14:29 GMT
+  recorded_at: Mon, 21 Sep 2015 20:38:55 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/exercism_api_fetch.yml
+++ b/test/fixtures/vcr_cassettes/exercism_api_fetch.yml
@@ -1,0 +1,32 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://localhost:4567/api/v1/iterations/go/leap/fetch?key=abc123
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - github.com/exercism/xapi
+      Content-Length:
+      - '0'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - private
+      X-Content-Type-Options:
+      - nosniff
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Sat, 19 Sep 2015 18:11:26 GMT
+recorded_with: VCR 2.9.3

--- a/test/xapi/exercism_io_test.rb
+++ b/test/xapi/exercism_io_test.rb
@@ -32,6 +32,21 @@ class ExercismIOTest < Minitest::Test
     end
   end
 
+  def test_fetch
+    key, language, slug = %w(abc123 go leap)
+    VCR.use_cassette('exercism_api_fetch') do
+      assert_equal nil, Xapi::ExercismIO.fetch_for(key, language, slug)
+    end
+    # ensure that ::fetch_for calls ::request
+    mock = MiniTest::Mock.new
+    path = "/api/v1/iterations/#{language}/#{slug}/fetch"
+    mock.expect(:call, nil, [:post, path, key])
+    Xapi::ExercismIO.stub(:request, mock) do
+      Xapi::ExercismIO.fetch_for(key, language, slug)
+    end
+    mock.verify
+  end
+
   def test_passes_error_on
     VCR.use_cassette('exercism_api_error') do
       assert_raises Xapi::ApiError do

--- a/test/xapi/homework_test.rb
+++ b/test/xapi/homework_test.rb
@@ -1,6 +1,7 @@
 require './test/test_helper'
 require 'json'
 require 'xapi/config'
+require 'xapi/exercism_io'
 require 'xapi/progression'
 require 'xapi/problem'
 require 'xapi/homework'
@@ -11,7 +12,9 @@ class HomeworkTest < Minitest::Test
   def homework_in(languages, data)
     homework = Xapi::Homework.new('abc123', languages, './test/fixtures')
     homework.stub(:data, data) do
-      yield homework
+      Xapi::ExercismIO.stub(:fetch_for, nil) do
+        yield homework
+      end
     end
   end
 


### PR DESCRIPTION
* Simplify Homework methods
* Allow ExercismIO to make requests other than GET
* Add ExercismIO::fetch_for to mark a problem fetched
* Call Exercism API to mark new problems as fetched
* Fix acceptance test failures
  * Configure acceptance tests to record new VCR episodes for reused cassettes.
  * Rerecord cassettes
  * Approve new responses