### PR TITLE
add /tracks/:id/problems route (and test)

### DIFF
--- a/lib/app/routes/tracks.rb
+++ b/lib/app/routes/tracks.rb
@@ -14,7 +14,7 @@ module Xapi
       # NOTE: THIS ROUTE MEANS WE CAN'T HAVE A PROBLEM NAMED "problems"!
       get '/tracks/:id/problems' do |id|
         summaries = find_track(id).problems.map { |problem|
-          { slug: problem.slug, blurb: problem.blurb, name: problem.name }
+          { slug: problem.slug, blurb: problem.blurb }
         }
         pg :summaries, locals: { summaries: summaries }
       end

--- a/lib/app/routes/tracks.rb
+++ b/lib/app/routes/tracks.rb
@@ -6,15 +6,15 @@ module Xapi
       end
 
       get '/tracks/:id' do |id|
-        pg :track, locals: { track: find_track(id)}
+        pg :track, locals: { track: find_track(id) }
       end
 
       # return track's problem summaries IN TRACK ORDER, not sorted by slug as
       # on /problems.  track problem screen only needs the things shown below.
       # NOTE: THIS ROUTE MEANS WE CAN'T HAVE A PROBLEM NAMED "problems"!
       get '/tracks/:id/problems' do |id|
-        summaries = find_track(id).problems.map { |p|
-          { :slug => p.slug, :blurb => p.blurb, :name => p.name }
+        summaries = find_track(id).problems.map { |problem|
+          { slug: problem.slug, blurb: problem.blurb, name: problem.name }
         }
         pg :summaries, locals: { summaries: summaries }
       end
@@ -46,7 +46,6 @@ module Xapi
         end
         track
       end
-
     end
   end
 end

--- a/lib/app/routes/tracks.rb
+++ b/lib/app/routes/tracks.rb
@@ -6,11 +6,17 @@ module Xapi
       end
 
       get '/tracks/:id' do |id|
-        track = config.find(id)
-        if track.is_a?(NullTrack)
-          halt 404, { error: "Track #{id} not found." }.to_json
-        end
-        pg :track, locals: { track: track }
+        pg :track, locals: { track: find_track(id)}
+      end
+
+      # return track's problem summaries IN TRACK ORDER, not sorted by slug as
+      # on /problems.  track problem screen only needs the things shown below.
+      # NOTE: THIS ROUTE MEANS WE CAN'T HAVE A PROBLEM NAMED "problems"!
+      get '/tracks/:id/problems' do |id|
+        summaries = find_track(id).problems.map { |p|
+          { :slug => p.slug, :blurb => p.blurb, :name => p.name }
+        }
+        pg :summaries, locals: { summaries: summaries }
       end
 
       get '/tracks/:id/:problem' do |id, slug|
@@ -30,6 +36,17 @@ module Xapi
         problem.validate or halt 404, { error: problem.error }.to_json
         pg :problem_test, locals: { problem: problem }
       end
+
+      private
+
+      def find_track(id)
+        track = config.find(id)
+        if track.is_a?(NullTrack)
+          halt 404, { error: "Track #{id} not found." }.to_json
+        end
+        track
+      end
+
     end
   end
 end

--- a/test/app/routes/tracks_test.rb
+++ b/test/app/routes/tracks_test.rb
@@ -75,4 +75,18 @@ class AppRoutesTracksTest < Minitest::Test
     options = { format: :json, name: 'get_specific_problem_tests' }
     Approvals.verify(last_response.body, options)
   end
+
+  def test_get_track_problems_in_right_order
+    slugs_from_track = get_slugs_from('/tracks/fake')
+    slugs_from_track_problems = get_slugs_from('/tracks/fake/problems')
+    assert_equal slugs_from_track, slugs_from_track_problems
+  end
+
+  private
+
+  def get_slugs_from(url)
+    get url
+    JSON.parse(last_response.body)['problems'].map { |p| p['slug'] }
+  end
+
 end

--- a/test/app/routes/tracks_test.rb
+++ b/test/app/routes/tracks_test.rb
@@ -88,5 +88,4 @@ class AppRoutesTracksTest < Minitest::Test
     get url
     JSON.parse(last_response.body)['problems'].map { |p| p['slug'] }
   end
-
 end


### PR DESCRIPTION
This PR adds a add `/tracks/:id/problems` route (and test for it).  This new route is intended to facilitate fixing the Exercism.IO bug https://github.com/exercism/exercism.io/issues/2577 (List exercises on language page in the track order).  I already have another solution working, but it is horribly inefficient; this solution not only would be more efficient, but it's even relatively clean, fitting in just fine with standard RESTful routing.  The downside is that there could never be a problem called "problems", as this PR will override that.