### PR TITLE
Always sort slugs in the same order

### DIFF
--- a/lib/xapi/metadata.rb
+++ b/lib/xapi/metadata.rb
@@ -17,7 +17,7 @@ module Xapi
     private_class_method :metadata_dir
 
     def self.slugs_in(dir)
-      Dir["#{dir}/*.yml"].map do |f|
+      Dir["#{dir}/*.yml"].sort.map do |f|
         f[REGEX_SLUG, 1]
       end
     end


### PR DESCRIPTION
Resolves test failures mentioned in #84.