### PR TITLE
[READY] #84 - Accept multiple tracks as parameters to the "fetch" endpoint.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ tmp
 test/fixtures/approvals/*.received.*
 coverage
 bin/configlet
+vendor/

--- a/test/v1/routes/exercises_filtering_test.rb
+++ b/test/v1/routes/exercises_filtering_test.rb
@@ -18,8 +18,6 @@ class V1RoutesExerciseFilteringTest < Minitest::Test
     VCR.use_cassette('exercism_api_current_exercises_v2') do
       get '/v2/exercises?tracks=fruit', key: 'abc123'
 
-      options = { format: :json, name: 'get_current_problems_by_language_v2' }
-
       json = JSON.parse(last_response.body)
       
       tracks_received = json['problems'].map{|it| it['track_id']}.uniq
@@ -32,8 +30,6 @@ class V1RoutesExerciseFilteringTest < Minitest::Test
     VCR.use_cassette('exercism_api_current_exercises_v2') do
       get '/v2/exercises?tracks=fruit,animal', key: 'abc123'
 
-      options = { format: :json, name: 'get_current_problems_by_language_v2' }
-
       json = JSON.parse(last_response.body)
       
       tracks_received = json['problems'].map{|it| it['track_id']}.uniq
@@ -45,8 +41,6 @@ class V1RoutesExerciseFilteringTest < Minitest::Test
   def test_that_empty_filter_returns_all
     VCR.use_cassette('exercism_api_current_exercises_v2') do
       get '/v2/exercises?tracks=', key: 'abc123'
-
-      options = { format: :json, name: 'get_current_problems_by_language_v2' }
 
       json = JSON.parse(last_response.body)
       

--- a/test/v1/routes/exercises_filtering_test.rb
+++ b/test/v1/routes/exercises_filtering_test.rb
@@ -44,6 +44,12 @@ class V1RoutesExerciseFilteringTest < Minitest::Test
     returns_tracks ['animal']
   end
 
+  def test_that_a_track_that_does_not_exist_returns_empty
+    getting '/v2/exercises?tracks=xxx-does-not-exist-xxx'
+    
+    returns_tracks []
+  end
+
   private
 
   def getting(url)
@@ -58,7 +64,7 @@ class V1RoutesExerciseFilteringTest < Minitest::Test
 
   def last_tracks
     json = JSON.parse(last_response.body)
-      
+
     tracks_received = json['problems'].map{|it| it['track_id']}.uniq
   end
 end

--- a/test/v1/routes/exercises_filtering_test.rb
+++ b/test/v1/routes/exercises_filtering_test.rb
@@ -1,0 +1,32 @@
+require './test/v1_helper'
+require 'rack/test'
+require './test/vcr_helper'
+
+class V1RoutesExerciseFilteringTest < Minitest::Test
+  include Rack::Test::Methods
+
+  def app
+    V1::App
+  end
+
+  # 
+  # Right now we have /v2/exercises and /v2/exercises/:track_id. Let's tweak the /v2/exercises to
+  # take an optional parameter ?tracks=a,b,c and if that parameter is passed, only return the data for those tracks.
+  #
+
+  def test_that_you_may_filter_to_single_track
+    VCR.use_cassette('exercism_api_current_exercises_v2') do
+      get '/v2/exercises?tracks=fruit', key: 'abc123'
+
+      options = { format: :json, name: 'get_current_problems_by_language_v2' }
+
+      json = JSON.parse(last_response.body)
+      
+      tracks_received = json['problems'].map{|it| it['track_id']}.uniq
+
+      assert_equal ['fruit'], tracks_received
+    end
+  end
+
+  # TEST: use comma or semi?
+end

--- a/test/v1/routes/exercises_filtering_test.rb
+++ b/test/v1/routes/exercises_filtering_test.rb
@@ -32,6 +32,12 @@ class V1RoutesExerciseFilteringTest < Minitest::Test
     returns_tracks ['animal', 'fake', 'fruit']
   end
 
+  def test_that_missing_filter_returns_all
+    getting '/v2/exercises'
+
+    returns_tracks ['animal', 'fake', 'fruit']
+  end
+
   def test_that_blank_space_is_ignored
     getting '/v2/exercises?tracks=%20animal%20%20'
 

--- a/test/v1/routes/exercises_filtering_test.rb
+++ b/test/v1/routes/exercises_filtering_test.rb
@@ -28,6 +28,20 @@ class V1RoutesExerciseFilteringTest < Minitest::Test
     end
   end
 
+  def test_that_you_may_filter_to_multiple_tracks
+    VCR.use_cassette('exercism_api_current_exercises_v2') do
+      get '/v2/exercises?tracks=fruit,animal', key: 'abc123'
+
+      options = { format: :json, name: 'get_current_problems_by_language_v2' }
+
+      json = JSON.parse(last_response.body)
+      
+      tracks_received = json['problems'].map{|it| it['track_id']}.uniq
+
+      assert_equal ['animal', 'fruit'], tracks_received.sort
+    end
+  end
+
   def test_that_empty_filter_returns_all
     VCR.use_cassette('exercism_api_current_exercises_v2') do
       get '/v2/exercises?tracks=', key: 'abc123'
@@ -41,6 +55,4 @@ class V1RoutesExerciseFilteringTest < Minitest::Test
       assert_equal ['animal', 'fake', 'fruit'], tracks_received
     end
   end
-
-  # TEST: use comma or semi?
 end

--- a/test/v1/routes/exercises_filtering_test.rb
+++ b/test/v1/routes/exercises_filtering_test.rb
@@ -28,5 +28,19 @@ class V1RoutesExerciseFilteringTest < Minitest::Test
     end
   end
 
+  def test_that_empty_filter_returns_all
+    VCR.use_cassette('exercism_api_current_exercises_v2') do
+      get '/v2/exercises?tracks=', key: 'abc123'
+
+      options = { format: :json, name: 'get_current_problems_by_language_v2' }
+
+      json = JSON.parse(last_response.body)
+      
+      tracks_received = json['problems'].map{|it| it['track_id']}.uniq
+
+      assert_equal ['animal', 'fake', 'fruit'], tracks_received
+    end
+  end
+
   # TEST: use comma or semi?
 end

--- a/test/v1/routes/exercises_filtering_test.rb
+++ b/test/v1/routes/exercises_filtering_test.rb
@@ -9,7 +9,7 @@ class V1RoutesExerciseFilteringTest < Minitest::Test
     V1::App
   end
 
-  # 
+  #
   # Right now we have /v2/exercises and /v2/exercises/:track_id. Let's tweak the /v2/exercises to
   # take an optional parameter ?tracks=a,b,c and if that parameter is passed, only return the data for those tracks.
   #
@@ -17,36 +17,36 @@ class V1RoutesExerciseFilteringTest < Minitest::Test
   def test_that_you_may_filter_to_single_track
     getting '/v2/exercises?tracks=fruit'
 
-    returns_tracks ['fruit']
+    returns_tracks %w( fruit )
   end
 
   def test_that_you_may_filter_to_multiple_tracks
     getting '/v2/exercises?tracks=fruit,animal'
 
-    returns_tracks ['animal', 'fruit']
+    returns_tracks %w( animal fruit )
   end
 
   def test_that_empty_filter_returns_all
     getting '/v2/exercises?tracks='
 
-    returns_tracks ['animal', 'fake', 'fruit']
+    returns_tracks %w( animal fake fruit )
   end
 
   def test_that_missing_filter_returns_all
     getting '/v2/exercises'
 
-    returns_tracks ['animal', 'fake', 'fruit']
+    returns_tracks %w( animal fake fruit )
   end
 
   def test_that_blank_space_is_ignored
     getting '/v2/exercises?tracks=%20animal%20%20'
 
-    returns_tracks ['animal']
+    returns_tracks %w( animal )
   end
 
   def test_that_a_track_that_does_not_exist_returns_empty
     getting '/v2/exercises?tracks=xxx-does-not-exist-xxx'
-    
+
     returns_tracks []
   end
 
@@ -63,8 +63,6 @@ class V1RoutesExerciseFilteringTest < Minitest::Test
   end
 
   def last_tracks
-    json = JSON.parse(last_response.body)
-
-    tracks_received = json['problems'].map{|it| it['track_id']}.uniq
+    JSON.parse(last_response.body)['problems'].map { |it| it['track_id'] }.uniq
   end
 end

--- a/test/v1/routes/exercises_filtering_test.rb
+++ b/test/v1/routes/exercises_filtering_test.rb
@@ -15,38 +15,40 @@ class V1RoutesExerciseFilteringTest < Minitest::Test
   #
 
   def test_that_you_may_filter_to_single_track
-    VCR.use_cassette('exercism_api_current_exercises_v2') do
-      get '/v2/exercises?tracks=fruit', key: 'abc123'
+    getting '/v2/exercises?tracks=fruit'
 
-      assert_equal ['fruit'], last_tracks
-    end
+    returns_tracks ['fruit']
   end
 
   def test_that_you_may_filter_to_multiple_tracks
-    VCR.use_cassette('exercism_api_current_exercises_v2') do
-      get '/v2/exercises?tracks=fruit,animal', key: 'abc123'
+    getting '/v2/exercises?tracks=fruit,animal'
 
-      assert_equal ['animal', 'fruit'], last_tracks
-    end
+    returns_tracks ['animal', 'fruit']
   end
 
   def test_that_empty_filter_returns_all
-    VCR.use_cassette('exercism_api_current_exercises_v2') do
-      get '/v2/exercises?tracks=', key: 'abc123'
+    getting '/v2/exercises?tracks='
 
-      assert_equal ['animal', 'fake', 'fruit'], last_tracks
-    end
+    returns_tracks ['animal', 'fake', 'fruit']
   end
 
   def test_that_blank_space_is_ignored
-    VCR.use_cassette('exercism_api_current_exercises_v2') do
-      get '/v2/exercises?tracks=%20animal%20%20', key: 'abc123'
-      
-      assert_equal ['animal'], last_tracks
-    end
+    getting '/v2/exercises?tracks=%20animal%20%20'
+
+    returns_tracks ['animal']
   end
 
   private
+
+  def getting(url)
+    VCR.use_cassette('exercism_api_current_exercises_v2') do
+      get url, key: 'abc123'
+    end
+  end
+
+  def returns_tracks(expected_tracks=[])
+    assert_equal expected_tracks, last_tracks
+  end
 
   def last_tracks
     json = JSON.parse(last_response.body)

--- a/test/v1/routes/exercises_filtering_test.rb
+++ b/test/v1/routes/exercises_filtering_test.rb
@@ -18,11 +18,7 @@ class V1RoutesExerciseFilteringTest < Minitest::Test
     VCR.use_cassette('exercism_api_current_exercises_v2') do
       get '/v2/exercises?tracks=fruit', key: 'abc123'
 
-      json = JSON.parse(last_response.body)
-      
-      tracks_received = json['problems'].map{|it| it['track_id']}.uniq
-
-      assert_equal ['fruit'], tracks_received
+      assert_equal ['fruit'], last_tracks
     end
   end
 
@@ -30,11 +26,7 @@ class V1RoutesExerciseFilteringTest < Minitest::Test
     VCR.use_cassette('exercism_api_current_exercises_v2') do
       get '/v2/exercises?tracks=fruit,animal', key: 'abc123'
 
-      json = JSON.parse(last_response.body)
-      
-      tracks_received = json['problems'].map{|it| it['track_id']}.uniq
-
-      assert_equal ['animal', 'fruit'], tracks_received.sort
+      assert_equal ['animal', 'fruit'], last_tracks
     end
   end
 
@@ -42,11 +34,23 @@ class V1RoutesExerciseFilteringTest < Minitest::Test
     VCR.use_cassette('exercism_api_current_exercises_v2') do
       get '/v2/exercises?tracks=', key: 'abc123'
 
-      json = JSON.parse(last_response.body)
-      
-      tracks_received = json['problems'].map{|it| it['track_id']}.uniq
-
-      assert_equal ['animal', 'fake', 'fruit'], tracks_received
+      assert_equal ['animal', 'fake', 'fruit'], last_tracks
     end
+  end
+
+  def test_that_blank_space_is_ignored
+    VCR.use_cassette('exercism_api_current_exercises_v2') do
+      get '/v2/exercises?tracks=%20animal%20%20', key: 'abc123'
+      
+      assert_equal ['animal'], last_tracks
+    end
+  end
+
+  private
+
+  def last_tracks
+    json = JSON.parse(last_response.body)
+      
+    tracks_received = json['problems'].map{|it| it['track_id']}.uniq
   end
 end

--- a/v1/routes/exercises.rb
+++ b/v1/routes/exercises.rb
@@ -9,7 +9,9 @@ module V1
 
       get '/v2/exercises' do
         require_key
-        problems = forward_errors { homework.problems }
+
+        problems = forward_errors { filter(homework.problems, params[:tracks]) }
+
         pg :problems, locals: { problems: problems }
       end
 
@@ -35,6 +37,13 @@ module V1
         problem = config.find(language).find(slug)
         problem.validate or halt 404, { error: problem.error }.to_json
         pg :problems, locals: { problems: [problem] }
+      end
+
+      private
+
+      def filter(what, track_ids=[])
+        return what if track_ids.empty?
+        what.select{|it| track_ids.include?(it.track_id)}
       end
     end
   end

--- a/v1/routes/exercises.rb
+++ b/v1/routes/exercises.rb
@@ -10,7 +10,7 @@ module V1
       get '/v2/exercises' do
         require_key
 
-        problems = forward_errors { filter(homework.problems, params[:tracks]) }
+        problems = forward_errors { filter(homework.problems, (params[:tracks] || [])) }
 
         pg :problems, locals: { problems: problems }
       end

--- a/v1/routes/exercises.rb
+++ b/v1/routes/exercises.rb
@@ -9,7 +9,9 @@ module V1
 
       get '/v2/exercises' do
         require_key
-        problems = forward_errors { filter(homework.problems, (params[:tracks] || [])) }
+        problems = forward_errors do
+          filter(homework.problems, (params[:tracks] || []))
+        end
         pg :problems, locals: { problems: problems }
       end
 
@@ -41,7 +43,7 @@ module V1
 
       def filter(what, track_ids=[])
         return what if track_ids.empty?
-        what.select{|it| track_ids.include?(it.track_id)}
+        what.select { |it| track_ids.include?(it.track_id) }
       end
     end
   end

--- a/v1/routes/exercises.rb
+++ b/v1/routes/exercises.rb
@@ -9,9 +9,7 @@ module V1
 
       get '/v2/exercises' do
         require_key
-
         problems = forward_errors { filter(homework.problems, (params[:tracks] || [])) }
-
         pg :problems, locals: { problems: problems }
       end
 


### PR DESCRIPTION
This patch adds support for filtering exercises by track with an URL like: 

```
/v2/exercises?tracks=fruit,animal
```

Examples [here](https://github.com/ben-biddington/x-api/blob/%2384/test/v1/routes/exercises_filtering_test.rb). They follow your `VCR` pattern with the detail suppressed a little.

* I think skewering [the filter](https://github.com/ben-biddington/x-api/blob/%2384/v1/routes/exercises.rb#L42) itself with unit test might be nicer than running the lot through web adapter. Perhaps something like [this](https://github.com/ben-biddington/x-api/commit/cb2d138310e42d55d8989acfb31352f604b1459d).
* I also wondered about moving the filtering closer to persistence (no sense querying for data we don't return) -- but on closer inspection `config` is in-memory
