### PR TITLE
Add filter for deprecated and foregone todo problems.

### DIFF
--- a/lib/xapi/track.rb
+++ b/lib/xapi/track.rb
@@ -34,6 +34,14 @@ module Xapi
       data['problems']
     end
 
+    def deprecated
+      data['deprecated']
+    end
+
+    def foregone
+      data['foregone']
+    end
+
     def docs
       @docs ||= Docs.new(track_path)
     end
@@ -44,7 +52,7 @@ module Xapi
     end
 
     def todo
-      metadata_slugs - slugs
+      metadata_slugs - slugs - deprecated - foregone
     end
 
     private

--- a/test/fixtures/tracks/animal/config.json
+++ b/test/fixtures/tracks/animal/config.json
@@ -6,5 +6,7 @@
   "test_pattern": "a.*animal",
   "problems": [
     "dog"
-  ]
+  ],
+  "deprecated": [],
+  "foregone": []
 }

--- a/test/fixtures/tracks/fake/config.json
+++ b/test/fixtures/tracks/fake/config.json
@@ -8,5 +8,7 @@
     "one",
     "two",
     "three"
-  ]
+  ],
+  "deprecated": [],
+  "foregone": []
 }

--- a/test/fixtures/tracks/fruit/config.json
+++ b/test/fixtures/tracks/fruit/config.json
@@ -7,5 +7,11 @@
     "apple",
     "banana",
     "cherry"
+  ],
+  "deprecated": [
+    "four"
+  ],
+  "foregone": [
+    "five"
   ]
 }

--- a/test/fixtures/tracks/jewels/config.json
+++ b/test/fixtures/tracks/jewels/config.json
@@ -4,5 +4,7 @@
   "repository": "https://github.com/exercism/xjewels",
   "active": false,
   "problems": [
-  ]
+  ],
+  "deprecated": [],
+  "foregone": []
 }

--- a/test/xapi/track_test.rb
+++ b/test/xapi/track_test.rb
@@ -22,7 +22,8 @@ class TrackTest < Minitest::Test
   end
 
   def test_todo
-    track = Xapi::Track.new(@path, "fruit", %w(apple banana dog one two))
+    track = Xapi::Track.new(@path, "fruit",
+                            %w(apple banana dog one two four five))
     assert_equal %w(dog one two), track.todo
   end
 


### PR DESCRIPTION
- Add filter for unneeded problems.
- Update test fixtures to include deprecated and foregone arrays.
- Update test to check that deprecated and foregone problems are not included in todo.

Closes https://github.com/exercism/todo/issues/171.