### PR TITLE
WIP Add checklist issue number to config

### DIFF
--- a/api/v3/views/track.pg
+++ b/api/v3/views/track.pg
@@ -1,5 +1,5 @@
 node track: track do
-  attributes :id, :language, :repository
+  attributes :id, :language, :repository, :checklist_issue
   node todo: todo
   node active: track.active?
   node implemented: track.problems.size > 0

--- a/api/v3/views/tracks.pg
+++ b/api/v3/views/tracks.pg
@@ -1,5 +1,5 @@
 collection tracks: tracks do |track|
-  attributes :id, :language, :repository
+  attributes :id, :language, :repository, :checklist_issue
   node todo: problems - track.slugs
   node active: track.active?
   node implemented: track.problems.size > 0

--- a/lib/xapi/track.rb
+++ b/lib/xapi/track.rb
@@ -34,7 +34,11 @@ module Xapi
       @implementations ||= Implementations.new(id, repository, problems, root)
     end
 
-    %w(language repository checklist_issue).each do |name|
+    def checklist_issue
+      config.fetch("checklist_issue", 1).to_s
+    end
+
+    %w(language repository).each do |name|
       define_method name do
         config[name].to_s.strip
       end

--- a/lib/xapi/track.rb
+++ b/lib/xapi/track.rb
@@ -34,7 +34,7 @@ module Xapi
       @implementations ||= Implementations.new(id, repository, problems, root)
     end
 
-    %w(language repository).each do |name|
+    %w(language repository checklist_issue).each do |name|
       define_method name do
         config[name].to_s.strip
       end

--- a/test/fixtures/approvals/v3_track.approved.txt
+++ b/test/fixtures/approvals/v3_track.approved.txt
@@ -2,6 +2,7 @@
 	"id" => "fake"
 	"language" => "Fake"
 	"repository" => "https://github.com/exercism/xfake"
+	"checklist_issue" => "5"
 	"todo" => ["banana", "cherry"]
 	"active" => true
 	"implemented" => true

--- a/test/fixtures/tracks/fake/config.json
+++ b/test/fixtures/tracks/fake/config.json
@@ -2,6 +2,7 @@
   "slug": "fake",
   "language": "Fake",
   "repository": "https://github.com/exercism/xfake",
+  "checklist_issue": "1",
   "active": true,
   "problems": [
     "hello-world",

--- a/test/fixtures/tracks/fake/config.json
+++ b/test/fixtures/tracks/fake/config.json
@@ -2,7 +2,7 @@
   "slug": "fake",
   "language": "Fake",
   "repository": "https://github.com/exercism/xfake",
-  "checklist_issue": "1",
+  "checklist_issue": 5,
   "active": true,
   "problems": [
     "hello-world",

--- a/test/xapi/track_test.rb
+++ b/test/xapi/track_test.rb
@@ -54,6 +54,12 @@ class TrackTest < Minitest::Test
     refute img.exists?, "should not have a nope.png"
   end
 
+  def test_track_with_default_checklist_issue
+    track = Xapi::Track.new('fruit', FIXTURE_PATH)
+
+    assert_equal "1", track.checklist_issue
+  end
+
   def test_custom_test_pattern
     track = Xapi::Track.new('fruit', FIXTURE_PATH)
 

--- a/test/xapi/track_test.rb
+++ b/test/xapi/track_test.rb
@@ -9,6 +9,7 @@ class TrackTest < Minitest::Test
     assert track.active?, "track 'fake' inactive"
     assert_equal "Fake", track.language
     assert_equal "https://github.com/exercism/xfake", track.repository
+    assert_equal "1", track.checklist_issue
 
     problems = %w(hello-world one two three)
     assert_equal problems, track.problems

--- a/test/xapi/track_test.rb
+++ b/test/xapi/track_test.rb
@@ -9,7 +9,7 @@ class TrackTest < Minitest::Test
     assert track.active?, "track 'fake' inactive"
     assert_equal "Fake", track.language
     assert_equal "https://github.com/exercism/xfake", track.repository
-    assert_equal "1", track.checklist_issue
+    assert_equal "5", track.checklist_issue
 
     problems = %w(hello-world one two three)
     assert_equal problems, track.problems


### PR DESCRIPTION
Fixes #109

Reads checklist_issue from `config.json` while assuming that the default issue number is "1"