### PR TITLE
API checks for the existence of a given exercise

### DIFF
--- a/api/v1/routes/tracks.rb
+++ b/api/v1/routes/tracks.rb
@@ -21,8 +21,15 @@ module V1
 
         implementation = track.implementations[slug]
         unless implementation.exists?
+
+          error = if Xapi.problems[slug].exists?
+            "Exercise '%s' isn't yet available in %s. Help us fix it by contributing to Exercism! Visit https://github.com/exercism/exercism.io/blob/master/CONTRIBUTING.md to get started!"
+          else
+            "Cannot find %s in any of our Exercism tracks!"
+          end
+
           halt 404, {
-            error: "No implementation for %s in track '%s'" % [slug, id],
+            error: error % [slug, id],
           }.to_json
         end
 


### PR DESCRIPTION
https://github.com/exercism/todo/issues/174

**DO NOT MERGE**

For some reason, running the API locally uses v1 routes instead of v3, I couldn't figure out how to get around this.  With the local API running, I navigate to `http://localhost:9292/tracks/ruby/grep` and see my expected response only when I modify `api/v1/routes/tracks.rb`:

```
{
error: "Exercise 'grep' isn't yet available in ruby. Help us fix it by contributing! Visit https://github.com/exercism/exercism.io/blob/master/CONTRIBUTING.md to get started!"
}