### PR TITLE
Run full test suite to get coverage on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ sudo: false
 rvm:
   - 2.2.5
 script:
-  - CI=1 bundle exec rake test:each
+  - CI=1 bundle exec rake test
+  - bundle exec rake test:each
   - bin/fetch-configlet
   - bin/verify-configs
   - bundle exec bin/verify-metadata


### PR DESCRIPTION
The test:each rake task appears to confound Coverall's ability to get the combined
coverage data.

This test suite is very quick, and it seems like we should just run the full test suite
for CI and the individual tests to make sure that everything is still independent.

Closes #119 (I think).

FYI @exercism/rgsoc2016 I think this is what you talked about in the chat the other day.