### PR TITLE
[Style] Fix Rubocop style violations

### DIFF
--- a/api/v1/routes/docs.rb
+++ b/api/v1/routes/docs.rb
@@ -2,7 +2,7 @@ module V1
   module Routes
     class Docs < Core
       get '/docs/:track' do |id|
-        pg :docs, locals:  { track: find_track(id) }
+        pg :docs, locals: { track: find_track(id) }
       end
     end
   end

--- a/test/api/v1/routes/exercises_filtering_test.rb
+++ b/test/api/v1/routes/exercises_filtering_test.rb
@@ -17,13 +17,13 @@ class V1RoutesExerciseFilteringTest < Minitest::Test
   def test_that_you_may_filter_to_single_track
     getting '/v2/exercises?tracks=fruit'
 
-    assert_returns_tracks %w( fruit )
+    assert_returns_tracks %w(fruit)
   end
 
   def test_that_you_may_filter_to_multiple_tracks
     getting '/v2/exercises?tracks=fake,jewels'
 
-    assert_returns_tracks %w( fake jewels )
+    assert_returns_tracks %w(fake jewels)
   end
 
   def test_that_empty_filter_returns_all
@@ -31,7 +31,7 @@ class V1RoutesExerciseFilteringTest < Minitest::Test
 
     # animal is excluded, because there are no more exercises in
     # that track.
-    assert_returns_tracks %w( fake fruit jewels )
+    assert_returns_tracks %w(fake fruit jewels)
   end
 
   def test_that_missing_filter_returns_all
@@ -39,13 +39,13 @@ class V1RoutesExerciseFilteringTest < Minitest::Test
 
     # animal is excluded, because there are no more exercises in
     # that track.
-    assert_returns_tracks %w( fake fruit jewels )
+    assert_returns_tracks %w(fake fruit jewels)
   end
 
   def test_that_blank_space_is_ignored
     getting '/v2/exercises?tracks=%20fake%20%20'
 
-    assert_returns_tracks %w( fake )
+    assert_returns_tracks %w(fake)
   end
 
   def test_that_a_track_that_does_not_exist_returns_empty


### PR DESCRIPTION
This fixes 11 rubocop warnings out of the current 13, which are all minor whitespace violations,
for the last 2 remaining however it wants to replace `fail` with `raise`, which doesn't seem reasonable to me (so I didn't touch that for now).

Relevant part:
```shell
Offenses:

test/api/v1/routes/exercises_test.rb:93:20: C: Always use raise to signal exceptions.
    error = proc { fail Exception.new("failing hard") }
                   ^^^^
api/services/exercism_io.rb:53:7: C: Always use raise to signal exceptions.
      fail Xapi::ApiError.new(data['error']) if data['error']
^^^^
```
Whole rubocop diff: https://gist.github.com/z2s8/b1a027e4fffe9f4e27af8e2280a90f2a