### PR TITLE
Replace calls to deprecated trackler methods

### DIFF
--- a/api/v3/routes/problems.rb
+++ b/api/v3/routes/problems.rb
@@ -3,7 +3,7 @@ module V3
     class Problems < Core
       get '/problems/data-todos' do
         problems = Trackler.problems.select { |problem|
-          problem.json_url.nil?
+          problem.canonical_data_url.nil?
         }
 
         pg :"problems/data_todos", locals: {

--- a/api/v3/views/problem/todos.pg
+++ b/api/v3/views/problem/todos.pg
@@ -1,8 +1,8 @@
 node :problem do
   node slug: problem.slug
   node blurb: problem.blurb
-  node readme_url: problem.md_url
-  node data: problem.json_url
+  node readme_url: problem.description_url
+  node data: problem.canonical_data_url
   node todos: todos
 
   collection implementations: implementations do |implementation|

--- a/api/v3/views/problems/data_todos.pg
+++ b/api/v3/views/problems/data_todos.pg
@@ -1,8 +1,8 @@
 collection problems: problems do |problem|
   node slug: problem.slug
   node blurb: problem.blurb
-  node readme_url: problem.md_url
-  node data: problem.json_url
+  node readme_url: problem.description_url
+  node data: problem.canonical_data_url
 
   collection implementations: implementations[problem.slug] do |implementation|
     node track_id: implementation.track_id

--- a/api/v3/views/track/todos.pg
+++ b/api/v3/views/track/todos.pg
@@ -5,8 +5,8 @@ node repository: track.repository
 collection todos: problems do |problem|
   node slug: problem.slug
   node blurb: problem.blurb
-  node readme_url: problem.md_url
-  node data: problem.json_url
+  node readme_url: problem.description_url
+  node data: problem.canonical_data_url
 
   collection implementations: implementations[problem.slug] do |implementation|
     node track_id: implementation.track_id


### PR DESCRIPTION
The trackler gem was using implementation-specific names for the x-common exercise data
files. This swaps out the calls to these methods with the new ones that describe the
purpose of the file.

Closes #145 

/cc @Insti 