### PR TITLE
Remove unnecessary getting of Problems

### DIFF
--- a/api/v1/routes/tracks.rb
+++ b/api/v1/routes/tracks.rb
@@ -4,7 +4,6 @@ module V1
       get '/tracks' do
         pg :tracks, locals: {
           tracks: Trackler.tracks,
-          problems: Trackler.problems,
           todos: Trackler.todos,
         }
       end
@@ -13,7 +12,6 @@ module V1
         track = find_track(id)
         pg :track, locals: {
           track: track,
-          problems: Trackler.problems,
           todos: Trackler.todos,
         }
       end

--- a/api/v3/routes/tracks.rb
+++ b/api/v3/routes/tracks.rb
@@ -4,7 +4,6 @@ module V3
       get '/tracks' do
         pg :tracks, locals: {
           tracks: Trackler.tracks,
-          problems: Trackler.problems,
           todos: Trackler.todos,
         }
       end


### PR DESCRIPTION
These routes set problems as a local but never used it.

Removing the local caused no tests to fail, so all seems good.