### PR TITLE
Use `Implementation#merge_files` instead of `files=`

### DIFF
--- a/api/v1/routes/exercises.rb
+++ b/api/v1/routes/exercises.rb
@@ -17,7 +17,7 @@ module V1
           next unless ti.exists?
 
           implementation = ti.dup
-          implementation.files = implementation.files.merge(solution["files"])
+          implementation.merge_files(solution["files"])
           implementations << implementation
         end
 


### PR DESCRIPTION
Use `merge_files` method rather than the deprecated `files=` method when adding the solution files to the implementation file bundle.

Silences deprecation warning.

## Requires trackler update ##

Dependency: https://github.com/exercism/trackler/pull/39