### PR TITLE
Eliminate implementation mutation

### DIFF
--- a/api/v1/views/restore.pg
+++ b/api/v1/views/restore.pg
@@ -1,0 +1,12 @@
+collection :problems => things_to_restore do |thing|
+  implementation = thing.implementation
+
+  node id: "%s/%s" % [implementation.track_id, implementation.problem.slug]
+  node track_id: implementation.track_id
+  node language: implementation.track_id
+  node slug: implementation.problem.slug
+  node name: implementation.problem.name
+  node files: thing.files
+  # deprecated
+  node fresh: false
+end


### PR DESCRIPTION
Mutating the implementation.files hash has caused problems with unrelated solution files being erroneously served to students. See: https://github.com/exercism/x-api/pull/153#issuecomment-303578409

The initial fix for this was to fix trackler to duplicate the files hash when duplicating the implementation: https://github.com/exercism/trackler/pull/51

But a better solution would be to eliminate the mutation of implementation completely.

This can be achieved by using a different view when restoring that separates the the files to be restored from the implementation.

Once this is merged it would be desirable to remove the `Trakler::Implementation#merge_files` method, so as to discourage mutating `Implementation` in the future.

I believe this is the only place where it was used.



The un-squashed refactoring commits can be seen at: https://github.com/Insti/x-api/pull/2